### PR TITLE
iOS Deeplinking Issue when app is not in background - Fixed

### DIFF
--- a/native-dronahq-invocation/reactnative/Sample/ios/NativeDeeplinkTest/AppDelegate.m
+++ b/native-dronahq-invocation/reactnative/Sample/ios/NativeDeeplinkTest/AppDelegate.m
@@ -46,4 +46,11 @@
 {
   return [RCTLinkingManager application:application openURL:url options:options];
 }
+
+
+- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler{
+  return [RCTLinkingManager application:application
+                   continueUserActivity:userActivity
+                     restorationHandler:restorationHandler];
+}
 @end

--- a/native-dronahq-invocation/reactnative/Sample/screens/Home.js
+++ b/native-dronahq-invocation/reactnative/Sample/screens/Home.js
@@ -16,13 +16,17 @@ class Home extends Component {
   };
 
   componentDidMount() {
+    //Used in both android and ios 
+    //But in ios this works only when app is in killed state
+    //also make sure to disable remote debugging and live reload
+    Linking.getInitialURL().then(url => {
+      this.navigate(url);
+    });
     if (Platform.OS === 'android') {
       // get the url from intent here
-      Linking.getInitialURL().then(url => {
-        this.navigate(url);
-      });
     } else {
-      Linking.addEventListener('url', this.handleNavigation);
+      //This is required for receiving the event when app is in background state
+      Linking.addEventListener('url', this.handleNavigation); 
     }
   }
 
@@ -43,7 +47,7 @@ class Home extends Component {
     //const id = route.match(/\/([^\/]+)\/?$/)[1];
     //const routeName = route.split('/')[0];
 
-    if (url != null && url.includes('nativetest')) {
+    if (url != null && url.includes('nonce') && url.includes('uid')) {
       this.props.navigation.navigate('Details', {
         Deep_linking_data: url,
       })


### PR DESCRIPTION
Fixed following issues -
1) When container app directly opens react native app, deeplink url is not received(when app is in background)
2) When app is killed state then also deeplink url is not received
P.S. - Remote debugging in React Native app for this to work.